### PR TITLE
Add black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+        language_version: python3.7

--- a/more/__init__.py
+++ b/more/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/more/webassets/core.py
+++ b/more/webassets/core.py
@@ -7,7 +7,7 @@ from . import directives
 
 
 class IncludeRequest(Request):
-    """ Adds the ability to include webassets bundles on the request.
+    """Adds the ability to include webassets bundles on the request.
 
     If the bundle does not exist, a KeyError will be raised during the
     rendering of the response, after the view has returned.
@@ -54,7 +54,7 @@ class WebassetsApp(App):
 
 @WebassetsApp.tween_factory()
 def webassets_injector_tween(app, handler):
-    """ Wraps the response with the injector and the publisher tween.
+    """Wraps the response with the injector and the publisher tween.
 
     See :class:`webassets.tweens.InjectorTween` and
     :class:`webassets.tweens.PublisherTween`.

--- a/more/webassets/directives.py
+++ b/more/webassets/directives.py
@@ -9,12 +9,12 @@ from webassets import Bundle, Environment
 
 
 class Asset(object):
-    """ Represents a registered asset which points to one or more files or
+    """Represents a registered asset which points to one or more files or
     child-assets.
 
     """
 
-    __slots__ = ('name', 'assets', 'filters')
+    __slots__ = ("name", "assets", "filters")
 
     def __init__(self, name, assets, filters):
         self.name = name
@@ -22,13 +22,15 @@ class Asset(object):
         self.filters = filters
 
     def __eq__(self, other):
-        return self.name == self.name \
-            and self.assets == self.assets \
+        return (
+            self.name == self.name
+            and self.assets == self.assets
             and self.filters == self.filters
+        )
 
     @property
     def is_pure(self):
-        """ Returns True if this asset is "pure".
+        """Returns True if this asset is "pure".
 
         Pure assets are assets which consist of a single file or a set of
         files which share one common extension.
@@ -38,15 +40,15 @@ class Asset(object):
         if self.is_single_file:
             return True
 
-        extensions = {a.split('.')[-1] for a in self.assets}
-        extensions |= {None for a in self.assets if '.' not in a}
+        extensions = {a.split(".")[-1] for a in self.assets}
+        extensions |= {None for a in self.assets if "." not in a}
 
         return len(extensions) == 1 and None not in extensions
 
     @property
     def is_single_file(self):
         """ Returns True if this repesents a single file asset. """
-        return len(self.assets) == 1 and '.' in self.assets[0]
+        return len(self.assets) == 1 and "." in self.assets[0]
 
     @property
     def path(self):
@@ -58,7 +60,7 @@ class Asset(object):
     def extension(self):
         """ Returns the extension of this asset if it's a pure asset. """
         if self.is_pure:
-            return self.assets[0].split('.')[-1]
+            return self.assets[0].split(".")[-1]
 
 
 class WebassetRegistry(object):
@@ -87,23 +89,23 @@ class WebassetRegistry(object):
         self.cached_bundles = {}
 
         #: The url passed to the webasset environment
-        self.url = 'assets'
+        self.url = "assets"
 
         #: more.webasset only publishes js/css files - other file extensions
         #: need to be compiled into either and mapped accordingly
         self.mapping = {
-            'coffee': 'js',
-            'dust': 'js',
-            'jst': 'js',
-            'jsx': 'js',
-            'less': 'css',
-            'sass': 'css',
-            'scss': 'css',
-            'ts': 'js',
+            "coffee": "js",
+            "dust": "js",
+            "jst": "js",
+            "jsx": "js",
+            "less": "css",
+            "sass": "css",
+            "scss": "css",
+            "ts": "js",
         }
 
     def register_path(self, path):
-        """ Registers the given path as a path to be searched for files.
+        """Registers the given path as a path to be searched for files.
 
         The paths are prepended, so each new path has higher precedence than
         all the already registered paths.
@@ -113,7 +115,7 @@ class WebassetRegistry(object):
         self.paths.insert(0, os.path.normpath(path))
 
     def register_filter(self, name, filter, produces=None):
-        """ Registers a filter, overriding any existing filter of the same
+        """Registers a filter, overriding any existing filter of the same
         name.
 
         """
@@ -121,33 +123,25 @@ class WebassetRegistry(object):
         self.filter_product[name] = produces or name
 
     def register_asset(self, name, assets, filters=None):
-        """ Registers a new asset.
+        """Registers a new asset."""
 
-        """
-
-        assert '.' not in name, "asset names may not contain dots ({})".format(
+        assert "." not in name, "asset names may not contain dots ({})".format(
             name
         )
 
         # keep track of asset bundles
-        self.assets[name] = Asset(
-            name=name,
-            assets=assets,
-            filters=filters
-        )
+        self.assets[name] = Asset(name=name, assets=assets, filters=filters)
 
         # and have one additional asset for each file
         for asset in assets:
             basename = os.path.basename(asset)
 
             # files are entries with an extension
-            if '.' in basename:
+            if "." in basename:
                 path = os.path.normpath(self.find_file(asset))
 
                 self.assets[basename] = Asset(
-                    name=basename,
-                    assets=(path, ),
-                    filters=filters
+                    name=basename, assets=(path,), filters=filters
                 )
             else:
                 assert asset in self.assets, "unknown asset {}".format(asset)
@@ -174,7 +168,7 @@ class WebassetRegistry(object):
         raise LookupError("Could not find {} in paths".format(name))
 
     def merge_filters(self, *filters):
-        """ Takes a list of filters and merges them.
+        """Takes a list of filters and merges them.
 
         The last filter has the highest precedence.
 
@@ -201,18 +195,17 @@ class WebassetRegistry(object):
         if asset.is_pure:
 
             if asset.is_single_file:
-                files = (asset.path, )
+                files = (asset.path,)
             else:
-                files = (
-                    a.path for a in (self.assets[a] for a in asset.assets))
+                files = (a.path for a in (self.assets[a] for a in asset.assets))
 
             extension = self.mapping.get(asset.extension, asset.extension)
-            assert extension in ('js', 'css')
+            assert extension in ("js", "css")
 
             yield Bundle(
                 *files,
                 filters=self.get_asset_filters(asset, all_filters),
-                output='{}.bundle.{}'.format(name, extension)
+                output="{}.bundle.{}".format(name, extension),
             )
         else:
             for sub in (self.assets[a] for a in asset.assets):
@@ -226,7 +219,7 @@ class WebassetRegistry(object):
             return None
 
         def append_filter(item):
-            str_classes = ("".__class__, b"".__class__, u"".__class__)
+            str_classes = ("".__class__, b"".__class__, "".__class__)
 
             if isinstance(item, str_classes):
                 bundle_filters.append(item)
@@ -250,41 +243,46 @@ class WebassetRegistry(object):
     def get_environment(self):
         """ Returns the webassets environment, registering all the bundles. """
 
-        debug = os.environ.get('MORE_WEBASSETS_DEBUG', '').lower().strip() in (
-            'true', '1'
+        debug = os.environ.get("MORE_WEBASSETS_DEBUG", "").lower().strip() in (
+            "true",
+            "1",
         )
 
         env = Environment(
             directory=self.output_path,
             load_path=self.paths,
             url=self.url,
-            debug=debug
+            debug=debug,
         )
 
         for asset in self.assets:
             bundles = tuple(self.get_bundles(asset))
 
-            js = tuple(b for b in bundles if b.output.endswith('.js'))
-            css = tuple(b for b in bundles if b.output.endswith('.css'))
+            js = tuple(b for b in bundles if b.output.endswith(".js"))
+            css = tuple(b for b in bundles if b.output.endswith(".css"))
 
             if js:
-                js_bundle = len(js) == 1 and js[0] or Bundle(
-                    *js, output='{}.bundle.js'.format(asset)
+                js_bundle = (
+                    len(js) == 1
+                    and js[0]
+                    or Bundle(*js, output="{}.bundle.js".format(asset))
                 )
             else:
                 js_bundle = None
 
             if css:
-                css_bundle = len(css) == 1 and css[0] or Bundle(
-                    *css, output='{}.bundle.css'.format(asset)
+                css_bundle = (
+                    len(css) == 1
+                    and css[0]
+                    or Bundle(*css, output="{}.bundle.css".format(asset))
                 )
             else:
                 css_bundle = None
 
             if js_bundle and css_bundle:
-                js_bundle.next_bundle = asset + '_1'
+                js_bundle.next_bundle = asset + "_1"
                 env.register(asset, js_bundle)
-                env.register(asset + '_1', css_bundle)
+                env.register(asset + "_1", css_bundle)
             elif js_bundle:
                 env.register(asset, js_bundle)
             else:
@@ -294,7 +292,6 @@ class WebassetRegistry(object):
 
 
 class PathMixin(object):
-
     def absolute_path(self, path):
         if os.path.isabs(path):
             return path
@@ -303,7 +300,7 @@ class PathMixin(object):
 
 
 class WebassetPath(Action, PathMixin):
-    """ Registers a path with more.webassets.
+    """Registers a path with more.webassets.
 
     Registered paths are searched for assets registered::
 
@@ -324,9 +321,7 @@ class WebassetPath(Action, PathMixin):
 
     """
 
-    config = {
-        'webasset_registry': WebassetRegistry
-    }
+    config = {"webasset_registry": WebassetRegistry}
 
     def identifier(self, webasset_registry):
         return object()
@@ -347,7 +342,7 @@ class WebassetPath(Action, PathMixin):
 
 
 class WebassetOutput(Action, PathMixin):
-    """ Sets the output path for all bundles.
+    """Sets the output path for all bundles.
 
     For example::
 
@@ -367,7 +362,7 @@ class WebassetOutput(Action, PathMixin):
 
 
 class WebassetFilter(Action):
-    """ Registers a default filter for an extension.
+    """Registers a default filter for an extension.
 
     Filters are strings interpreted by `webasset`::
 
@@ -403,7 +398,7 @@ class WebassetFilter(Action):
 
 
 class WebassetMapping(Action):
-    """ Maps an extension to either css or js.
+    """Maps an extension to either css or js.
 
     You usually don't have to use this, as more.webassets comes with default
     values. If you do, please open an issue so your mapping may be added
@@ -434,7 +429,7 @@ class WebassetMapping(Action):
 
 
 class WebassetUrl(Action):
-    """ Defines the url under which the bundles should be served.
+    """Defines the url under which the bundles should be served.
 
     Passed to the webasset environment, this is basically a url path prefix::
 
@@ -456,7 +451,7 @@ class WebassetUrl(Action):
 
 
 class Webasset(Action):
-    """ Registers an asset which may then be included in the page.
+    """Registers an asset which may then be included in the page.
 
     For example::
 
@@ -509,7 +504,7 @@ class Webasset(Action):
         WebassetMapping,
         WebassetOutput,
         WebassetPath,
-        WebassetUrl
+        WebassetUrl,
     ]
     group_class = WebassetPath
 

--- a/more/webassets/tests/conftest.py
+++ b/more/webassets/tests/conftest.py
@@ -18,4 +18,4 @@ def current_path():
 
 @pytest.fixture
 def fixtures_path(current_path):
-    return os.path.join(current_path, 'fixtures')
+    return os.path.join(current_path, "fixtures")

--- a/more/webassets/tests/test_directives.py
+++ b/more/webassets/tests/test_directives.py
@@ -14,121 +14,118 @@ def test_webasset_path(current_path):
 
     @App.webasset_path()
     def get_path():
-        return './fixtures'
+        return "./fixtures"
 
     @App.webasset_path()
     def get_overlapping_path():
-        return os.path.join(current_path, './fixtures')
+        return os.path.join(current_path, "./fixtures")
 
     @App.webasset_path()
     def get_current_path():
-        return '.'
+        return "."
 
     @App.webasset_path()
     def get_parent_path():
-        return '..'
+        return ".."
 
     morepath.commit(App)
 
     app = App()
 
     assert app.config.webasset_registry.paths == [
-        os.path.normpath(os.path.join(current_path, '..')),
-        os.path.normpath(os.path.join(current_path, '.')),
-        os.path.normpath(os.path.join(current_path, 'fixtures')),
-        os.path.normpath(os.path.join(current_path, 'fixtures')),
+        os.path.normpath(os.path.join(current_path, "..")),
+        os.path.normpath(os.path.join(current_path, ".")),
+        os.path.normpath(os.path.join(current_path, "fixtures")),
+        os.path.normpath(os.path.join(current_path, "fixtures")),
     ]
 
 
 def test_webasset_relative(current_path):
-
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
     def get_relative_path():
-        return 'fixtures'
+        return "fixtures"
 
     morepath.commit(App)
 
     assert App().config.webasset_registry.paths == [
-        os.path.join(current_path, 'fixtures')
+        os.path.join(current_path, "fixtures")
     ]
 
 
 def test_webasset_path_inheritance(tempdir, current_path):
 
-    os.mkdir(os.path.join(tempdir, 'A'))
-    os.mkdir(os.path.join(tempdir, 'B'))
-    os.mkdir(os.path.join(tempdir, 'C'))
+    os.mkdir(os.path.join(tempdir, "A"))
+    os.mkdir(os.path.join(tempdir, "B"))
+    os.mkdir(os.path.join(tempdir, "C"))
 
     class A(WebassetsApp):
         pass
 
     @A.webasset_path()
     def get_path_a():
-        return os.path.join(tempdir, 'A')
+        return os.path.join(tempdir, "A")
 
     class B(WebassetsApp):
         pass
 
     @B.webasset_path()
     def get_path_b():
-        return os.path.join(tempdir, 'B')
+        return os.path.join(tempdir, "B")
 
     class C(B, A):
         pass
 
     @C.webasset_path()
     def get_path_c():
-        return os.path.join(tempdir, 'C')
+        return os.path.join(tempdir, "C")
 
     class D(A, B):
         pass
 
     @D.webasset_path()
     def get_path_c_2():
-        return os.path.join(tempdir, 'C')
+        return os.path.join(tempdir, "C")
 
     # the order of A and B is defined by the order they are scanned with
     morepath.commit(A, B, C, D)
 
     assert C().config.webasset_registry.paths == [
-        os.path.join(tempdir, 'C'),
-        os.path.join(tempdir, 'B'),
-        os.path.join(tempdir, 'A'),
+        os.path.join(tempdir, "C"),
+        os.path.join(tempdir, "B"),
+        os.path.join(tempdir, "A"),
     ]
 
     assert D().config.webasset_registry.paths == [
-        os.path.join(tempdir, 'C'),
-        os.path.join(tempdir, 'B'),
-        os.path.join(tempdir, 'A'),
+        os.path.join(tempdir, "C"),
+        os.path.join(tempdir, "B"),
+        os.path.join(tempdir, "A"),
     ]
 
 
 def test_webasset_filter():
-
     class Base(WebassetsApp):
         pass
 
-    @Base.webasset_filter('js')
+    @Base.webasset_filter("js")
     def get_base_js_filter():
-        return 'jsmin'
+        return "jsmin"
 
     class App(WebassetsApp):
         pass
 
-    @App.webasset_filter('js')
+    @App.webasset_filter("js")
     def get_js_filter():
-        return 'rjsmin'
+        return "rjsmin"
 
     morepath.commit(App)
 
-    assert App().config.webasset_registry.filters == {'js': 'rjsmin'}
+    assert App().config.webasset_registry.filters == {"js": "rjsmin"}
 
 
 def test_webasset_filter_chain(fixtures_path):
-
     class App(WebassetsApp):
         pass
 
@@ -136,28 +133,27 @@ def test_webasset_filter_chain(fixtures_path):
     def get_path():
         return fixtures_path
 
-    @App.webasset_filter('js', produces='css')
+    @App.webasset_filter("js", produces="css")
     def foo_filter():
-        return 'jsmin'
+        return "jsmin"
 
-    @App.webasset_filter('css')
+    @App.webasset_filter("css")
     def bar_filter():
-        return 'cssmin'
+        return "cssmin"
 
-    @App.webasset('common')
+    @App.webasset("common")
     def get_common_assets():
-        yield 'jquery.js'
+        yield "jquery.js"
 
     morepath.commit(App)
 
-    common = list(App().config.webasset_registry.get_bundles('common'))
+    common = list(App().config.webasset_registry.get_bundles("common"))
     assert len(common) == 1
-    assert common[0].filters[0].name == 'jsmin'
-    assert common[0].filters[1].name == 'cssmin'
+    assert common[0].filters[0].name == "jsmin"
+    assert common[0].filters[1].name == "cssmin"
 
 
 def test_webasset_directive(tempdir, fixtures_path):
-
     class App(WebassetsApp):
         pass
 
@@ -169,62 +165,56 @@ def test_webasset_directive(tempdir, fixtures_path):
     def get_output_path():
         return tempdir
 
-    @App.webasset('common')
+    @App.webasset("common")
     def get_common_assets():
-        yield 'jquery.js'
-        yield 'underscore.js'
+        yield "jquery.js"
+        yield "underscore.js"
 
     morepath.commit(App)
 
     app = App()
 
     assert app.config.webasset_registry.assets == {
-        'jquery.js': Asset(
-            name='jquery.js',
-            assets=(os.path.join(fixtures_path, 'jquery.js'), ),
-            filters={}
+        "jquery.js": Asset(
+            name="jquery.js",
+            assets=(os.path.join(fixtures_path, "jquery.js"),),
+            filters={},
         ),
-        'underscore.js': Asset(
-            name='underscore.js',
-            assets=(os.path.join(fixtures_path, 'underscore.js'), ),
-            filters={}
+        "underscore.js": Asset(
+            name="underscore.js",
+            assets=(os.path.join(fixtures_path, "underscore.js"),),
+            filters={},
         ),
-        'common': Asset(
-            name='common',
-            assets=('jquery.js', 'underscore.js'),
-            filters={}
-        )
+        "common": Asset(
+            name="common", assets=("jquery.js", "underscore.js"), filters={}
+        ),
     }
 
-    common = list(app.config.webasset_registry.get_bundles('common'))
+    common = list(app.config.webasset_registry.get_bundles("common"))
 
     assert len(common) == 1
-    assert common[0].output.endswith('common.bundle.js')
+    assert common[0].output.endswith("common.bundle.js")
     assert common[0].contents == (
-        os.path.join(fixtures_path, 'jquery.js'),
-        os.path.join(fixtures_path, 'underscore.js')
+        os.path.join(fixtures_path, "jquery.js"),
+        os.path.join(fixtures_path, "underscore.js"),
     )
 
-    jquery = list(app.config.webasset_registry.get_bundles('jquery.js'))
+    jquery = list(app.config.webasset_registry.get_bundles("jquery.js"))
 
     assert len(jquery) == 1
-    assert jquery[0].output.endswith('jquery.js.bundle.js')
-    assert jquery[0].contents == (
-        os.path.join(fixtures_path, 'jquery.js'),
-    )
+    assert jquery[0].output.endswith("jquery.js.bundle.js")
+    assert jquery[0].contents == (os.path.join(fixtures_path, "jquery.js"),)
 
-    underscore = list(
-        app.config.webasset_registry.get_bundles('underscore.js'))
+    underscore = list(app.config.webasset_registry.get_bundles("underscore.js"))
 
     assert len(underscore) == 1
-    assert underscore[0].output.endswith('underscore.js.bundle.js')
+    assert underscore[0].output.endswith("underscore.js.bundle.js")
     assert underscore[0].contents == (
-        os.path.join(fixtures_path, 'underscore.js'),
+        os.path.join(fixtures_path, "underscore.js"),
     )
 
 
 def test_webasset_override_filters(tempdir, fixtures_path):
-
     class App(WebassetsApp):
         pass
 
@@ -236,34 +226,33 @@ def test_webasset_override_filters(tempdir, fixtures_path):
     def get_output_path():
         return tempdir
 
-    @App.webasset('jquery')
+    @App.webasset("jquery")
     def get_jquery_asset():
-        yield 'jquery.js'
+        yield "jquery.js"
 
-    @App.webasset_filter('js')
+    @App.webasset_filter("js")
     def get_js_filter():
-        return 'rjsmin'
+        return "rjsmin"
 
     class DebugApp(App):
         pass
 
-    @DebugApp.webasset_filter('js')
+    @DebugApp.webasset_filter("js")
     def get_debug_js_filter():
         return None
 
     morepath.commit(DebugApp, App)
 
-    bundles = list(App().config.webasset_registry.get_bundles('jquery'))
+    bundles = list(App().config.webasset_registry.get_bundles("jquery"))
     assert len(bundles) == 1
-    assert bundles[0].filters[0].name == 'rjsmin'
+    assert bundles[0].filters[0].name == "rjsmin"
 
-    bundles = list(DebugApp().config.webasset_registry.get_bundles('jquery'))
+    bundles = list(DebugApp().config.webasset_registry.get_bundles("jquery"))
     assert len(bundles) == 1
     assert not bundles[0].filters
 
 
 def test_webasset_override_filter_through_bundle(tempdir, fixtures_path):
-
     class App(WebassetsApp):
         pass
 
@@ -275,34 +264,33 @@ def test_webasset_override_filter_through_bundle(tempdir, fixtures_path):
     def get_output_path():
         return tempdir
 
-    @App.webasset('jquery')
+    @App.webasset("jquery")
     def get_jquery_asset():
-        yield 'jquery.js'
+        yield "jquery.js"
 
-    @App.webasset_filter('js')
+    @App.webasset_filter("js")
     def get_js_filter():
-        return 'rjsmin'
+        return "rjsmin"
 
     class DebugApp(App):
         pass
 
-    @DebugApp.webasset('common', filters={'js': None})
+    @DebugApp.webasset("common", filters={"js": None})
     def get_debug_js_filter():
-        yield 'jquery'
+        yield "jquery"
 
     morepath.commit(DebugApp, App)
 
-    bundles = list(App().config.webasset_registry.get_bundles('jquery'))
+    bundles = list(App().config.webasset_registry.get_bundles("jquery"))
     assert len(bundles) == 1
-    assert bundles[0].filters[0].name == 'rjsmin'
+    assert bundles[0].filters[0].name == "rjsmin"
 
-    bundles = list(DebugApp().config.webasset_registry.get_bundles('common'))
+    bundles = list(DebugApp().config.webasset_registry.get_bundles("common"))
     assert len(bundles) == 1
     assert not bundles[0].filters
 
 
 def test_global_filter_is_only_a_default(tempdir, fixtures_path):
-
     class App(WebassetsApp):
         pass
 
@@ -314,23 +302,22 @@ def test_global_filter_is_only_a_default(tempdir, fixtures_path):
     def get_output_path():
         return tempdir
 
-    @App.webasset('jquery', filters={'js': None})
+    @App.webasset("jquery", filters={"js": None})
     def get_jquery_asset():
-        yield 'jquery.js'
+        yield "jquery.js"
 
-    @App.webasset_filter('js')
+    @App.webasset_filter("js")
     def get_js_filter():
-        return 'rjsmin'
+        return "rjsmin"
 
     morepath.commit(App)
 
-    bundles = list(App().config.webasset_registry.get_bundles('jquery'))
+    bundles = list(App().config.webasset_registry.get_bundles("jquery"))
     assert len(bundles) == 1
     assert not bundles[0].filters
 
 
 def test_global_filter_is_only_a_default_with_bundle(tempdir, fixtures_path):
-
     class App(WebassetsApp):
         pass
 
@@ -342,31 +329,30 @@ def test_global_filter_is_only_a_default_with_bundle(tempdir, fixtures_path):
     def get_output_path():
         return tempdir
 
-    @App.webasset('jquery', filters={'js': None})
+    @App.webasset("jquery", filters={"js": None})
     def get_jquery_asset():
-        yield 'jquery.js'
+        yield "jquery.js"
 
-    @App.webasset('common')
+    @App.webasset("common")
     def get_common_asset():
-        yield 'jquery'
+        yield "jquery"
 
-    @App.webasset_filter('js')
+    @App.webasset_filter("js")
     def get_js_filter():
-        return 'rjsmin'
+        return "rjsmin"
 
     morepath.commit(App)
 
-    bundles = list(App().config.webasset_registry.get_bundles('common'))
+    bundles = list(App().config.webasset_registry.get_bundles("common"))
     assert len(bundles) == 1
     assert not bundles[0].filters
 
-    bundles = list(App().config.webasset_registry.get_bundles('jquery'))
+    bundles = list(App().config.webasset_registry.get_bundles("jquery"))
     assert len(bundles) == 1
     assert not bundles[0].filters
 
 
 def test_webasset_mixed_bundles(tempdir, fixtures_path):
-
     class App(WebassetsApp):
         pass
 
@@ -378,29 +364,24 @@ def test_webasset_mixed_bundles(tempdir, fixtures_path):
     def get_output_path():
         return tempdir
 
-    @App.webasset('common')
+    @App.webasset("common")
     def get_jquery_asset():
-        yield 'jquery.js'
-        yield 'extra.css'
+        yield "jquery.js"
+        yield "extra.css"
 
     morepath.commit(App)
 
-    bundles = list(App().config.webasset_registry.get_bundles('common'))
+    bundles = list(App().config.webasset_registry.get_bundles("common"))
     assert len(bundles) == 2
 
-    assert bundles[0].output.endswith('jquery.js.bundle.js')
-    assert bundles[0].contents == (
-        os.path.join(fixtures_path, 'jquery.js'),
-    )
+    assert bundles[0].output.endswith("jquery.js.bundle.js")
+    assert bundles[0].contents == (os.path.join(fixtures_path, "jquery.js"),)
 
-    assert bundles[1].output.endswith('extra.css.bundle.css')
-    assert bundles[1].contents == (
-        os.path.join(fixtures_path, 'extra.css'),
-    )
+    assert bundles[1].output.endswith("extra.css.bundle.css")
+    assert bundles[1].contents == (os.path.join(fixtures_path, "extra.css"),)
 
 
 def test_webasset_compiled_bundle(tempdir, fixtures_path):
-
     class App(WebassetsApp):
         pass
 
@@ -412,33 +393,28 @@ def test_webasset_compiled_bundle(tempdir, fixtures_path):
     def get_output_path():
         return tempdir
 
-    @App.webasset_filter('scss')
+    @App.webasset_filter("scss")
     def get_scss_filter():
-        return 'pyscss'
+        return "pyscss"
 
-    @App.webasset('theme')
+    @App.webasset("theme")
     def get_jquery_asset():
-        yield 'main.scss'
-        yield 'extra.css'
+        yield "main.scss"
+        yield "extra.css"
 
     morepath.commit(App)
 
-    bundles = list(App().config.webasset_registry.get_bundles('theme'))
+    bundles = list(App().config.webasset_registry.get_bundles("theme"))
     assert len(bundles) == 2
 
-    assert bundles[0].output.endswith('main.scss.bundle.css')
-    assert bundles[0].contents == (
-        os.path.join(fixtures_path, 'main.scss'),
-    )
+    assert bundles[0].output.endswith("main.scss.bundle.css")
+    assert bundles[0].contents == (os.path.join(fixtures_path, "main.scss"),)
 
-    assert bundles[1].output.endswith('extra.css.bundle.css')
-    assert bundles[1].contents == (
-        os.path.join(fixtures_path, 'extra.css'),
-    )
+    assert bundles[1].output.endswith("extra.css.bundle.css")
+    assert bundles[1].contents == (os.path.join(fixtures_path, "extra.css"),)
 
 
 def test_webasset_environment(tempdir, fixtures_path):
-
     class App(WebassetsApp):
         pass
 
@@ -450,67 +426,67 @@ def test_webasset_environment(tempdir, fixtures_path):
     def get_output_path():
         return tempdir
 
-    @App.webasset_filter('scss')
+    @App.webasset_filter("scss")
     def get_scss_filter():
-        return 'pyscss'
+        return "pyscss"
 
-    @App.webasset('js')
+    @App.webasset("js")
     def get_js_asset():
-        yield 'jquery.js'
-        yield 'underscore.js'
+        yield "jquery.js"
+        yield "underscore.js"
 
-    @App.webasset('css')
+    @App.webasset("css")
     def get_css_asset():
-        yield 'main.scss'
-        yield 'extra.css'
+        yield "main.scss"
+        yield "extra.css"
 
-    @App.webasset('common')
+    @App.webasset("common")
     def get_common_assets():
-        yield 'js'
-        yield 'css'
+        yield "js"
+        yield "css"
 
     morepath.commit(App)
 
     e = App().config.webasset_registry.get_environment()
 
-    for asset in ('jquery.js', 'underscore.js'):
-        assert e[asset].output.endswith('{}.bundle.js'.format(asset))
+    for asset in ("jquery.js", "underscore.js"):
+        assert e[asset].output.endswith("{}.bundle.js".format(asset))
         assert e[asset].contents == (os.path.join(fixtures_path, asset),)
         assert len(e[asset].urls()) == 1
 
-    for asset in ('main.scss', 'extra.css'):
-        assert e[asset].output.endswith('{}.bundle.css'.format(asset))
+    for asset in ("main.scss", "extra.css"):
+        assert e[asset].output.endswith("{}.bundle.css".format(asset))
         assert e[asset].contents == (os.path.join(fixtures_path, asset),)
         assert len(e[asset].urls()) == 1
 
-    assert e['js'].output.endswith('js.bundle.js')
-    assert e['js'].contents == (
-        os.path.join(fixtures_path, 'jquery.js'),
-        os.path.join(fixtures_path, 'underscore.js'),
+    assert e["js"].output.endswith("js.bundle.js")
+    assert e["js"].contents == (
+        os.path.join(fixtures_path, "jquery.js"),
+        os.path.join(fixtures_path, "underscore.js"),
     )
 
-    assert len(e['js'].urls()) == 1
+    assert len(e["js"].urls()) == 1
 
-    assert e['css'].output.endswith('css.bundle.css')
-    assert len(e['css'].contents) == 2
-    assert e['css'].contents[0].output.endswith('main.scss.bundle.css')
-    assert e['css'].contents[0].contents == (
-        os.path.join(fixtures_path, 'main.scss'),
+    assert e["css"].output.endswith("css.bundle.css")
+    assert len(e["css"].contents) == 2
+    assert e["css"].contents[0].output.endswith("main.scss.bundle.css")
+    assert e["css"].contents[0].contents == (
+        os.path.join(fixtures_path, "main.scss"),
     )
 
-    assert e['css'].contents[1].output.endswith('extra.css.bundle.css')
-    assert e['css'].contents[1].contents == (
-        os.path.join(fixtures_path, 'extra.css'),
+    assert e["css"].contents[1].output.endswith("extra.css.bundle.css")
+    assert e["css"].contents[1].contents == (
+        os.path.join(fixtures_path, "extra.css"),
     )
 
-    assert len(e['css'].urls()) == 1
+    assert len(e["css"].urls()) == 1
 
-    assert e['common'].output.endswith('js.bundle.js')
-    assert e['common'].contents == e['js'].contents
-    assert len(e['common'].urls()) == 1
+    assert e["common"].output.endswith("js.bundle.js")
+    assert e["common"].contents == e["js"].contents
+    assert len(e["common"].urls()) == 1
 
-    assert e['common_1'].contents[0].output == e['css'].contents[0].output
-    assert e['common_1'].contents[0].contents == e['css'].contents[0].contents
-    assert e['common_1'].contents[1].output == e['css'].contents[1].output
-    assert e['common_1'].contents[1].contents == e['css'].contents[1].contents
-    assert len(e['common_1'].urls()) == 1
+    assert e["common_1"].contents[0].output == e["css"].contents[0].output
+    assert e["common_1"].contents[0].contents == e["css"].contents[0].contents
+    assert e["common_1"].contents[1].output == e["css"].contents[1].output
+    assert e["common_1"].contents[1].contents == e["css"].contents[1].contents
+    assert len(e["common_1"].urls()) == 1

--- a/more/webassets/tests/test_webassets.py
+++ b/more/webassets/tests/test_webassets.py
@@ -10,44 +10,54 @@ from webtest import TestApp as Client
 
 
 def prepare_fixtures(directory):
-    os.mkdir(os.path.join(directory, 'common'))
-    os.mkdir(os.path.join(directory, 'output'))
-    os.mkdir(os.path.join(directory, 'theme'))
+    os.mkdir(os.path.join(directory, "common"))
+    os.mkdir(os.path.join(directory, "output"))
+    os.mkdir(os.path.join(directory, "theme"))
 
     # if those javascripts are changed, the tests below need to be updated
     # with the correct md5 hashes
-    with open(os.path.join(directory, 'common', 'jquery.js'), 'w') as f:
-        f.write("""
+    with open(os.path.join(directory, "common", "jquery.js"), "w") as f:
+        f.write(
+            """
             /* fake jquery */
             var $ = function(){};
-        """)
+        """
+        )
 
-    with open(os.path.join(directory, 'common', 'underscore.js'), 'w') as f:
-        f.write("""
+    with open(os.path.join(directory, "common", "underscore.js"), "w") as f:
+        f.write(
+            """
             /* fake underscore */
             var _ = function(){};
-        """)
+        """
+        )
 
-    with open(os.path.join(directory, 'theme', 'main.scss'), 'w') as f:
-        f.write("""
+    with open(os.path.join(directory, "theme", "main.scss"), "w") as f:
+        f.write(
+            """
             body {
                 a {
                     color: blue;
                 }
             }
-        """)
+        """
+        )
 
-    with open(os.path.join(directory, 'theme', 'other.css'), 'w') as f:
-        f.write("""
+    with open(os.path.join(directory, "theme", "other.css"), "w") as f:
+        f.write(
+            """
             h1 {
                 font-size: 2rem;
             }
-        """)
+        """
+        )
 
-    with open(os.path.join(directory, 'common', 'extra.js'), 'w') as f:
-        f.write("""
+    with open(os.path.join(directory, "common", "extra.js"), "w") as f:
+        f.write(
+            """
             $(document).ready(function(){});
-        """)
+        """
+        )
 
 
 def spawn_test_app(tempdir):
@@ -64,7 +74,7 @@ def spawn_test_app(tempdir):
 
     def render_plain(content, request):
         response = morepath.Response(content)
-        response.content_type = 'text/plain'
+        response.content_type = "text/plain"
         return response
 
     class App(WebassetsApp):
@@ -72,64 +82,64 @@ def spawn_test_app(tempdir):
 
     @App.webasset_path()
     def get_default_assets_path():
-        return os.path.join(tempdir, 'common')
+        return os.path.join(tempdir, "common")
 
     @App.webasset_path()
     def get_theme_assets_path():
-        return os.path.join(tempdir, 'theme')
+        return os.path.join(tempdir, "theme")
 
     @App.webasset_output()
     def get_output_path():
-        return os.path.join(tempdir, 'output')
+        return os.path.join(tempdir, "output")
 
-    @App.webasset_filter('js')
+    @App.webasset_filter("js")
     def get_js_filter():
-        return 'rjsmin'
+        return "rjsmin"
 
-    @App.webasset_filter('scss')
+    @App.webasset_filter("scss")
     def get_scss_filter():
-        return 'pyscss'
+        return "pyscss"
 
-    @App.webasset(name='common')
+    @App.webasset(name="common")
     def get_common_assets():
-        yield 'jquery.js'
-        yield 'underscore.js'
+        yield "jquery.js"
+        yield "underscore.js"
 
-    @App.webasset(name='extra')
+    @App.webasset(name="extra")
     def get_extra_asset():
-        yield 'extra.js'
+        yield "extra.js"
 
-    @App.webasset(name='theme')
+    @App.webasset(name="theme")
     def get_theme_asset():
-        yield 'main.scss'
+        yield "main.scss"
 
-    @App.path('')
+    @App.path("")
     class Root(object):
         pass
 
     @App.html(model=Root)
     def index(self, request):
-        bundle = request.params.get('bundle')
+        bundle = request.params.get("bundle")
 
         if bundle:
             request.include(bundle)
 
         return html
 
-    @App.view(model=Root, name='plain', render=render_plain)
+    @App.view(model=Root, name="plain", render=render_plain)
     def plain(self, request):
-        request.include('common')
+        request.include("common")
         return html
 
-    @App.html(model=Root, name='put', request_method='PUT')
+    @App.html(model=Root, name="put", request_method="PUT")
     def put(self, request):
-        request.include('common')
+        request.include("common")
         return html
 
-    @App.html(model=Root, name='alljs')
+    @App.html(model=Root, name="alljs")
     def alljs(self, request):
-        request.include('common')
-        request.include('extra')
+        request.include("common")
+        request.include("extra")
         return html
 
     morepath.scan(more.webassets)
@@ -141,79 +151,81 @@ def spawn_test_app(tempdir):
 def test_inject_webassets(tempdir):
     client = Client(spawn_test_app(tempdir))
 
-    assert '<head></head>' in client.get('/').text
+    assert "<head></head>" in client.get("/").text
 
     with pytest.raises(KeyError):
-        assert '<head></head>' in client.get('?bundle=inexistant').text
+        assert "<head></head>" in client.get("?bundle=inexistant").text
 
     # the version of these assets stays the same because it's basically the
     # md5 hash of the javascript files included
     injected_html = (
         '<script type="text/javascript" '
-        'src="/assets/common.bundle.js?ddc71aa3"></script></body>')
+        'src="/assets/common.bundle.js?ddc71aa3"></script></body>'
+    )
 
-    assert injected_html in client.get('?bundle=common').text
+    assert injected_html in client.get("?bundle=common").text
 
     injected_html = (
         '<link rel="stylesheet" type="text/css" '
-        'href="/assets/theme.bundle.css?32fda411"></head>')
+        'href="/assets/theme.bundle.css?32fda411"></head>'
+    )
 
-    assert injected_html in client.get('?bundle=theme').text
+    assert injected_html in client.get("?bundle=theme").text
 
-    page = client.get('/alljs').text
-    assert page.find('common.bundle.js') < page.find('extra.bundle.js')
+    page = client.get("/alljs").text
+    assert page.find("common.bundle.js") < page.find("extra.bundle.js")
 
 
 def test_publish_webassets(tempdir):
     client = Client(spawn_test_app(tempdir))
 
-    url = '/assets/common.bundle.js?ddc71aa3'
+    url = "/assets/common.bundle.js?ddc71aa3"
 
     # before the urls() have not been called by the injector, the bundles
     # won't have been created
     assert client.get(url, expect_errors=True).status_code == 404
 
-    client.get('?bundle=common')
+    client.get("?bundle=common")
 
-    assert client.get(url).text == 'var $=function(){};var _=function(){};'
+    assert client.get(url).text == "var $=function(){};var _=function(){};"
     assert client.get(url).expires.year == datetime.utcnow().year + 10
-    assert client.get(url).content_type == 'text/javascript'
+    assert client.get(url).content_type == "text/javascript"
 
     # do the same for css
-    url = '/assets/theme.bundle.css?32fda411'
+    url = "/assets/theme.bundle.css?32fda411"
 
     assert client.get(url, expect_errors=True).status_code == 404
 
-    client.get('?bundle=theme')
+    client.get("?bundle=theme")
 
-    assert client.get(url).text == 'body a {\n  color: blue; }\n'
+    assert client.get(url).text == "body a {\n  color: blue; }\n"
     assert client.get(url).expires.year == datetime.utcnow().year + 10
-    assert client.get(url).content_type == 'text/css'
+    assert client.get(url).content_type == "text/css"
 
 
 def test_webassets_unhandled_content_type(tempdir):
     client = Client(spawn_test_app(tempdir))
 
-    assert '<head></head>' in client.get('/plain').text
+    assert "<head></head>" in client.get("/plain").text
 
 
 def test_webassets_unhandled_request_method(tempdir):
     client = Client(spawn_test_app(tempdir))
 
-    assert '<head></head>' in client.put('/put').text
+    assert "<head></head>" in client.put("/put").text
 
 
 def test_is_subpath(tempdir):
-    assert is_subpath('/', '/test')
-    assert is_subpath('/asdf', '/asdf/asdf')
-    assert not is_subpath('/asdf/', '/asdf')
-    assert not is_subpath('/a', '/b')
-    assert not is_subpath('/a', '/a/../b')
+    assert is_subpath("/", "/test")
+    assert is_subpath("/asdf", "/asdf/asdf")
+    assert not is_subpath("/asdf/", "/asdf")
+    assert not is_subpath("/a", "/b")
+    assert not is_subpath("/a", "/a/../b")
 
 
 def test_insecure_path_element():
-    assert has_insecure_path_element('../test.txt')
-    assert has_insecure_path_element('./test.txt')
-    assert has_insecure_path_element('/test.txt')
-    assert not has_insecure_path_element('test.txt')
-    assert not has_insecure_path_element('asdf/asdf/test.txt')
+    assert has_insecure_path_element("../test.txt")
+    assert has_insecure_path_element("./test.txt")
+    assert has_insecure_path_element("/test.txt")
+    assert not has_insecure_path_element("test.txt")
+    assert not has_insecure_path_element("asdf/asdf/test.txt")

--- a/more/webassets/tweens.py
+++ b/more/webassets/tweens.py
@@ -12,24 +12,25 @@ except ImportError:
 
 
 # content types and methods that get handled by the injector/publisher
-CONTENT_TYPES = {'text/html', 'application/xhtml+xml'}
-METHODS = {'GET', 'POST', 'HEAD'}
+CONTENT_TYPES = {"text/html", "application/xhtml+xml"}
+METHODS = {"GET", "POST", "HEAD"}
 
 # arbitrarily define forever as 10 years in the future
 FOREVER = timedelta(days=365 * 10).total_seconds()
 
 
 # what separators does this operating system provide that are not a slash?
-_os_alt_seps = set(sep for sep in [os.path.sep, os.path.altsep]
-                   if sep not in (None, '/'))
+_os_alt_seps = set(
+    sep for sep in [os.path.sep, os.path.altsep] if sep not in (None, "/")
+)
 
 # what elements may not be in a path element?
-_insecure_elements = set(['..', '.', '']) | _os_alt_seps
+_insecure_elements = set(["..", ".", ""]) | _os_alt_seps
 
 
 def is_subpath(directory, path):
     """ Returns true if the given path is inside the given directory. """
-    directory = os.path.join(os.path.realpath(directory), '')
+    directory = os.path.join(os.path.realpath(directory), "")
     path = os.path.realpath(path)
 
     # return true, if the common prefix of both is equal to directory
@@ -38,10 +39,10 @@ def is_subpath(directory, path):
 
 
 def has_insecure_path_element(path):
-    """ Returns true if the given path contains an insecure path element.
+    """Returns true if the given path contains an insecure path element.
     That is '..' or '.' or ''
     """
-    if _insecure_elements.intersection(path.split('/')):
+    if _insecure_elements.intersection(path.split("/")):
         return True
 
     return False
@@ -64,7 +65,7 @@ class InjectorTween(object):
                 self._urls[resource].extend(bundle.urls())
 
                 try:
-                    bundle = self.environment[getattr(bundle, 'next_bundle')]
+                    bundle = self.environment[getattr(bundle, "next_bundle")]
                 except (AttributeError, KeyError):
                     bundle = None
 
@@ -73,12 +74,12 @@ class InjectorTween(object):
     def urls_to_inject(self, request, suffix=None):
         for resource in request.included_assets:
             for url in self.urls_by_resource(resource):
-                filename = url.split('?')[0]
+                filename = url.split("?")[0]
 
                 if suffix and not filename.endswith(suffix):
                     continue
 
-                yield '/' + url
+                yield "/" + url
 
     def __call__(self, request):
         response = self.handler(request)
@@ -92,31 +93,31 @@ class InjectorTween(object):
         if response.content_type.lower() not in CONTENT_TYPES:
             return response
 
-        scripts = '\n'.join(
+        scripts = "\n".join(
             '<script type="text/javascript" src="{}"></script>'.format(url)
-            for url in self.urls_to_inject(request, '.js')
+            for url in self.urls_to_inject(request, ".js")
         )
 
-        stylesheets = '\n'.join(
+        stylesheets = "\n".join(
             '<link rel="stylesheet" type="text/css" href="{}">'.format(url)
-            for url in self.urls_to_inject(request, '.css')
+            for url in self.urls_to_inject(request, ".css")
         )
 
         if scripts:
             response.body = response.body.replace(
-                b'</body>', scripts.encode('utf-8') + b'</body>', 1
+                b"</body>", scripts.encode("utf-8") + b"</body>", 1
             )
 
         if stylesheets:
             response.body = response.body.replace(
-                b'</head>', stylesheets.encode('utf-8') + b'</head>', 1
+                b"</head>", stylesheets.encode("utf-8") + b"</head>", 1
             )
 
         return response
 
 
 class PublisherTween(object):
-    """ Returns the webassets if the request begins with the
+    """Returns the webassets if the request begins with the
     :attr:`WebassetsApp.webassets_url`.
 
     """
@@ -131,7 +132,7 @@ class PublisherTween(object):
         if publisher_signature != self.environment.url:
             return self.handler(request)
 
-        subpath = request.path_info.replace(publisher_signature, '').strip('/')
+        subpath = request.path_info.replace(publisher_signature, "").strip("/")
         subpath = unquote(subpath)
 
         if has_insecure_path_element(subpath):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.black]
+line-length = 80
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.git
+    | \.tox
+    | env
+    | build
+    | dist
+  )/
+)
+'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[flake8]
+show-source = True
+ignore = E203, E731, W503, N801
+max-line-length = 88
+
+[tool:pytest]
+testpaths = more/webassets
+
+[coverage:run]
+omit = more/webassets/tests/*
+source = more/webassets
+
+[coverage:report]
+show_missing = True

--- a/setup.py
+++ b/setup.py
@@ -42,12 +42,13 @@ setup(
     ],
     extras_require=dict(
         test=[
-            'coverage',
-            'pytest',
-            'webtest',
-            'pyscss',
-            'tox'
+            "pytest >= 2.9.0",
+            "WebTest >= 2.0.14",
+            "pytest-remove-stale-bytecode",
+            "pyscss"
         ],
+        pep8=["flake8", "black"],
+        coverage=["pytest-cov"],
     ),
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -2,22 +2,21 @@
 
 from setuptools import setup, find_packages
 
-name = 'more.webassets'
-description = (
-    'An opinionated Webassets integration for Morepath.'
-)
-version = '0.5.1'
+name = "more.webassets"
+description = "An opinionated Webassets integration for Morepath."
+version = "0.5.1"
 
 
 def get_long_description():
     import io
-    readme = io.open('README.rst', encoding='utf-8').read()
-    history = io.open('HISTORY.rst', encoding='utf-8').read()
+
+    readme = io.open("README.rst", encoding="utf-8").read()
+    history = io.open("HISTORY.rst", encoding="utf-8").read()
 
     # cut the part before the description to avoid repetition on pypi
-    readme = readme[readme.index(description) + len(description):]
+    readme = readme[readme.index(description) + len(description) :]
 
-    return '\n'.join((readme, history))
+    return "\n".join((readme, history))
 
 
 setup(
@@ -25,38 +24,33 @@ setup(
     version=version,
     description=description,
     long_description=get_long_description(),
-    url='http://github.com/morepath/more.webassets',
-    author='Seantis GmbH',
-    author_email='info@seantis.ch',
-    license='BSD',
-    packages=find_packages(exclude=['ez_setup']),
-    namespace_packages=name.split('.')[:-1],
+    url="http://github.com/morepath/more.webassets",
+    author="Seantis GmbH",
+    author_email="info@seantis.ch",
+    license="BSD",
+    packages=find_packages(exclude=["ez_setup"]),
+    namespace_packages=name.split(".")[:-1],
     include_package_data=True,
     zip_safe=False,
-    platforms='any',
-    install_requires=[
-        'morepath>=0.16',
-        'ordered-set',
-        'webassets',
-        'webob'
-    ],
+    platforms="any",
+    install_requires=["morepath>=0.16", "ordered-set", "webassets", "webob"],
     extras_require=dict(
         test=[
             "pytest >= 2.9.0",
             "WebTest >= 2.0.14",
             "pytest-remove-stale-bytecode",
-            "pyscss"
+            "pyscss",
         ],
         pep8=["flake8", "black"],
         coverage=["pytest-cov"],
     ),
     classifiers=[
-        'Intended Audience :: Developers',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'License :: OSI Approved :: BSD License',
-    ]
+        "Intended Audience :: Developers",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "License :: OSI Approved :: BSD License",
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,24 @@
 [tox]
-envlist = py36,py37,py38,pep8,coverage
+envlist = py36, py37, py38, pypy3, coverage, pep8
+skipsdist = True
+skip_missing_interpreters = True
 
 [testenv]
-deps = -e{toxinidir}[test]
+usedevelop = True
+extras = test
 
 commands = pytest -v {posargs}
 
 [testenv:pep8]
-basepython = python3.8
-deps = flake8
-       pep8
-commands = flake8 more setup.py
+basepython = python3.7
+extras = pep8
+
+commands = flake8 .
+           black --check .
 
 [testenv:coverage]
 basepython = python3.8
-deps = {[testenv]deps}
-commands =
-    coverage run --source more.webassets -m pytest {posargs}
-    coverage report -m
+extras = test
+         coverage
 
-[pytest]
-testpaths = more
+commands = pytest --cov more.webassets {posargs}


### PR DESCRIPTION
This merge requests adds black for Python to the tools used when running the pep8 compliance tests.

It follows the morepath/reg project so that they now share their test infrastructure more.

The code has been then passed through black.