### PR TITLE
Fixes a depreciation warning

### DIFF
--- a/more/webassets/tests/conftest.py
+++ b/more/webassets/tests/conftest.py
@@ -4,7 +4,7 @@ import tempfile
 import shutil
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def tempdir():
     directory = tempfile.mkdtemp()
     yield directory


### PR DESCRIPTION
Should fix this particular warning when running tox with reference to issue #10.

```
more/webassets/tests/conftest.py:7
  /home/jugmac00/Projects/more.webassets/more/webassets/tests/conftest.py:7: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture
```