### PR TITLE
Ensure assets are also included in error views.

### DIFF
--- a/more/webassets/core.py
+++ b/more/webassets/core.py
@@ -52,7 +52,7 @@ class WebassetsApp(App):
     webasset = directive(directives.Webasset)
 
 
-@WebassetsApp.tween_factory()
+@WebassetsApp.tween_factory(over=excview_tween_factory)
 def webassets_injector_tween(app, handler):
     """Wraps the response with the injector and the publisher tween.
 

--- a/more/webassets/core.py
+++ b/more/webassets/core.py
@@ -3,6 +3,7 @@ from morepath.request import Request
 from morepath.app import App
 from dectate import directive
 from ordered_set import OrderedSet
+from morepath.error import excview_tween_factory
 from . import directives
 
 

--- a/more/webassets/core.py
+++ b/more/webassets/core.py
@@ -3,7 +3,7 @@ from morepath.request import Request
 from morepath.app import App
 from dectate import directive
 from ordered_set import OrderedSet
-from morepath.error import excview_tween_factory
+from morepath.core import excview_tween_factory
 from . import directives
 
 


### PR DESCRIPTION
Register `webassets_injector_tween` after `excview_tween_factory` so that assets are included in error views.

## Why this?
Here is a real world example to demonstrate why this is beneficial: Say you have a 404 page with navigation and it uses `Webassets`, the navigation will not actually work for all 404 pages.

This could be patched in the application that depends on `more.webassets`, but I think does not belong here and is not elegant.

```python
if not WebassetsApp.dectate._directives[0][0].kw:
    from morepath.core import excview_tween_factory
    WebassetsApp.dectate._directives[0][0].kw['over'] = excview_tween_factory
```
