### PR TITLE
Add type hints

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ Changelog
 0.5.2 (unreleased)
 ~~~~~~~~~~~~~~~~~~~
 
+- Minor robustness improvements
+
+- Add type hints
+
 - Switch to PEP-420 namespace package
 
 - Drop support for Python below 3.10

--- a/more/webassets/__init__.py
+++ b/more/webassets/__init__.py
@@ -1,1 +1,3 @@
-from more.webassets.core import WebassetsApp  # noqa
+from more.webassets.core import WebassetsApp
+
+__all__ = ("WebassetsApp",)

--- a/more/webassets/core.py
+++ b/more/webassets/core.py
@@ -1,13 +1,32 @@
-from more.webassets.tweens import InjectorTween, PublisherTween
-from morepath.request import Request
-from morepath.app import App
-from dectate import directive
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from ordered_set import OrderedSet
+
+from dectate import directive
+from morepath.app import App
 from morepath.core import excview_tween_factory
+from morepath.request import Request
+
 from . import directives
+from .tweens import InjectorTween, PublisherTween
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeVar
+
+    from morepath.types import Tween
+
+    _AppT = TypeVar(
+        "_AppT", bound="WebassetsApp", default="WebassetsApp", covariant=True
+    )
+else:
+    from typing import TypeVar
+
+    _AppT = TypeVar("_AppT", bound="WebassetsApp", covariant=True)
 
 
-class IncludeRequest(Request):
+class IncludeRequest(Request[_AppT]):
     """Adds the ability to include webassets bundles on the request.
 
     If the bundle does not exist, a KeyError will be raised during the
@@ -27,11 +46,16 @@ class IncludeRequest(Request):
 
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.included_assets = OrderedSet()
+    included_assets: OrderedSet[str]
 
-    def include(self, resource):
+    # NOTE: Preserve the signature of the super-class, without duplicating it
+    if not TYPE_CHECKING:
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.included_assets = OrderedSet()
+
+    def include(self, resource: str) -> None:
         self.included_assets.add(resource)
 
 
@@ -54,7 +78,7 @@ class WebassetsApp(App):
 
 
 @WebassetsApp.tween_factory(over=excview_tween_factory)
-def webassets_injector_tween(app, handler):
+def webassets_injector_tween(app: WebassetsApp, handler: Tween) -> Tween:
     """Wraps the response with the injector and the publisher tween.
 
     See :class:`webassets.tweens.InjectorTween` and

--- a/more/webassets/directives.py
+++ b/more/webassets/directives.py
@@ -1,11 +1,23 @@
+from __future__ import annotations
+
 import atexit
 import inspect
 import os.path
 import shutil
 import tempfile
+from typing import TYPE_CHECKING
 
 from dectate import Action
-from webassets import Bundle, Environment
+from webassets.bundle import Bundle
+from webassets.env import Environment
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
+    from typing_extensions import Self
+
+    from dectate import CodeInfo
+
+    from .types import Filter
 
 
 class Asset:
@@ -16,20 +28,26 @@ class Asset:
 
     __slots__ = ("name", "assets", "filters")
 
-    def __init__(self, name, assets, filters):
+    def __init__(
+        self,
+        name: str,
+        assets: Sequence[str],
+        filters: Mapping[str, Filter | None] | None,
+    ) -> None:
         self.name = name
-        self.assets = assets
-        self.filters = filters
+        self.assets = tuple(assets)
+        self.filters = dict(filters) if filters else {}
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
-            self.name == self.name
-            and self.assets == self.assets
-            and self.filters == self.filters
+            isinstance(other, self.__class__)
+            and self.name == other.name
+            and self.assets == other.assets
+            and self.filters == other.filters
         )
 
     @property
-    def is_pure(self):
+    def is_pure(self) -> bool:
         """Returns True if this asset is "pure".
 
         Pure assets are assets which consist of a single file or a set of
@@ -40,59 +58,60 @@ class Asset:
         if self.is_single_file:
             return True
 
-        extensions = {a.split(".")[-1] for a in self.assets}
+        extensions: set[str | None] = {a.split(".")[-1] for a in self.assets}
         extensions |= {None for a in self.assets if "." not in a}
 
         return len(extensions) == 1 and None not in extensions
 
     @property
-    def is_single_file(self):
+    def is_single_file(self) -> bool:
         """Returns True if this repesents a single file asset."""
         return len(self.assets) == 1 and "." in self.assets[0]
 
     @property
-    def path(self):
+    def path(self) -> str:
         """Returns the path to the single file asset if possible."""
         assert self.is_single_file
         return self.assets[0]
 
     @property
-    def extension(self):
+    def extension(self) -> str | None:
         """Returns the extension of this asset if it's a pure asset."""
         if self.is_pure:
             return self.assets[0].split(".")[-1]
+        return None
 
 
 class WebassetRegistry:
     """A registry managing webasset bundles registered through directives."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         #: A list of all paths which should be searched for files (in order)
-        self.paths = []
+        self.paths: list[str] = []
 
         #: The default filters for extensions. Each extension has a webassets
         #: filter string associated with it. (e.g. {'js': 'rjsmin'})
-        self.filters = {}
+        self.filters: dict[str, Filter | None] = {}
 
         #: The extension the filter at self.filters[key] produces
-        self.filter_product = {}
+        self.filter_product: dict[str, str] = {}
 
         #: :class:`Asset` objects keyed by their name
-        self.assets = {}
+        self.assets: dict[str, Asset] = {}
 
         #: The output path for all bundles (a temporary directory by default)
         self.output_path = temporary_directory = tempfile.mkdtemp()
         atexit.register(shutil.rmtree, temporary_directory)
 
         #: A cache of created bundles
-        self.cached_bundles = {}
+        self.cached_bundles: dict[str, Bundle] = {}
 
         #: The url passed to the webasset environment
         self.url = "assets"
 
         #: more.webasset only publishes js/css files - other file extensions
         #: need to be compiled into either and mapped accordingly
-        self.mapping = {
+        self.mapping: dict[str, str] = {
             "coffee": "js",
             "dust": "js",
             "jst": "js",
@@ -103,7 +122,7 @@ class WebassetRegistry:
             "ts": "js",
         }
 
-    def register_path(self, path):
+    def register_path(self, path: str) -> None:
         """Registers the given path as a path to be searched for files.
 
         The paths are prepended, so each new path has higher precedence than
@@ -113,7 +132,9 @@ class WebassetRegistry:
         assert os.path.isabs(path), "absolute paths only"
         self.paths.insert(0, os.path.normpath(path))
 
-    def register_filter(self, name, filter, produces=None):
+    def register_filter(
+        self, name: str, filter: Filter | None, produces: str | None = None
+    ) -> None:
         """Registers a filter, overriding any existing filter of the same
         name.
 
@@ -121,7 +142,12 @@ class WebassetRegistry:
         self.filters[name] = filter
         self.filter_product[name] = produces or name
 
-    def register_asset(self, name, assets, filters=None):
+    def register_asset(
+        self,
+        name: str,
+        assets: Sequence[str],
+        filters: Mapping[str, Filter | None] | None = None,
+    ) -> None:
         """Registers a new asset."""
 
         assert "." not in name, f"asset names may not contain dots ({name})"
@@ -143,7 +169,7 @@ class WebassetRegistry:
             else:
                 assert asset in self.assets, f"unknown asset {asset}"
 
-    def find_file(self, name):
+    def find_file(self, name: str) -> str:
         """Searches for the given file by name using the current paths."""
 
         if os.path.isabs(name):
@@ -164,13 +190,15 @@ class WebassetRegistry:
 
         raise LookupError(f"Could not find {name} in paths")
 
-    def merge_filters(self, *filters):
+    def merge_filters(
+        self, *filters: Mapping[str, Filter | None] | None
+    ) -> dict[str, Filter | None]:
         """Takes a list of filters and merges them.
 
         The last filter has the highest precedence.
 
         """
-        result = {}
+        result: dict[str, Filter | None] = {}
 
         for filter in filters:
             if filter:
@@ -178,7 +206,9 @@ class WebassetRegistry:
 
         return result
 
-    def get_bundles(self, name, filters=None):
+    def get_bundles(
+        self, name: str, filters: Mapping[str, Filter | None] | None = None
+    ) -> Generator[Bundle]:
         """Yields all the bundles for the given name (an asset)."""
 
         assert name in self.assets, f"unknown asset {name}"
@@ -191,11 +221,13 @@ class WebassetRegistry:
 
         if asset.is_pure:
             if asset.is_single_file:
-                files = (asset.path,)
+                files: Iterable[str] = (asset.path,)
             else:
                 files = (a.path for a in (self.assets[a] for a in asset.assets))
 
-            extension = self.mapping.get(asset.extension, asset.extension)
+            extension = asset.extension
+            assert extension is not None
+            extension = self.mapping.get(extension, extension)
             assert extension in ("js", "css")
 
             yield Bundle(
@@ -207,35 +239,38 @@ class WebassetRegistry:
             for sub in (self.assets[a] for a in asset.assets):
                 yield from self.get_bundles(sub.name, overriding_filters)
 
-    def get_asset_filters(self, asset, filters):
+    def get_asset_filters(
+        self, asset: Asset, filters: Mapping[str, Filter | None]
+    ) -> list[str] | None:
         """Returns the filters used for the given asset."""
 
         if not asset.is_pure:
             return None
 
-        def append_filter(item):
-            str_classes = ("".__class__, b"".__class__, "".__class__)
-
-            if isinstance(item, str_classes):
+        def append_filter(item: Filter | None) -> None:
+            if item is None:
+                pass
+            elif isinstance(item, (str, bytes)):
                 bundle_filters.append(item)
             else:
                 bundle_filters.extend(item)
 
-        bundle_filters = []
+        extension = asset.extension
+        assert extension is not None
+        bundle_filters: list[str] = []
 
-        if filters.get(asset.extension) is not None:
-            append_filter(filters[asset.extension])
+        append_filter(filters.get(extension))
 
         # include the filters for the resulting file to produce a chain
         # of filters (for example React JSX -> Javascript -> Minified)
-        product = self.filter_product.get(asset.extension)
+        product = self.filter_product.get(extension)
 
-        if product and product != asset.extension and product in filters:
-            append_filter(filters[product])
+        if product and product != extension:
+            append_filter(filters.get(product))
 
         return bundle_filters
 
-    def get_environment(self):
+    def get_environment(self) -> Environment:
         """Returns the webassets environment, registering all the bundles."""
 
         debug = os.environ.get("MORE_WEBASSETS_DEBUG", "").lower().strip() in (
@@ -273,7 +308,7 @@ class WebassetRegistry:
                 css_bundle = None
 
             if js_bundle and css_bundle:
-                js_bundle.next_bundle = asset + "_1"
+                js_bundle.next_bundle = asset + "_1"  # type: ignore[attr-defined]
                 env.register(asset, js_bundle)
                 env.register(asset + "_1", css_bundle)
             elif js_bundle:
@@ -285,10 +320,17 @@ class WebassetRegistry:
 
 
 class PathMixin:
-    def absolute_path(self, path):
+    if TYPE_CHECKING:
+        # forward declare CodeInfo
+        @property
+        def code_info(self) -> CodeInfo | None:
+            raise NotImplementedError
+
+    def absolute_path(self, path: str) -> str:
         if os.path.isabs(path):
             return path
         else:
+            assert self.code_info is not None
             return os.path.join(os.path.dirname(self.code_info.path), path)
 
 
@@ -316,18 +358,21 @@ class WebassetPath(Action, PathMixin):
 
     config = {"webasset_registry": WebassetRegistry}
 
-    def identifier(self, webasset_registry):
+    def identifier(self, webasset_registry: WebassetRegistry) -> object:
         return object()
 
-    def absolute_path(self, path):
+    def absolute_path(self, path: str) -> str:
         if os.path.isabs(path):
             return path
         else:
+            assert self.code_info is not None
             return os.path.abspath(
                 os.path.join(os.path.dirname(self.code_info.path), path)
             )
 
-    def perform(self, obj, webasset_registry):
+    def perform(
+        self, obj: Callable[[], str], webasset_registry: WebassetRegistry
+    ) -> None:
         path = self.absolute_path(obj())
         assert os.path.isdir(path), f"'{path}' does not exist"
 
@@ -347,10 +392,12 @@ class WebassetOutput(Action, PathMixin):
 
     group_class = WebassetPath
 
-    def identifier(self, webasset_registry):
+    def identifier(self, webasset_registry: WebassetRegistry) -> type[Self]:
         return self.__class__
 
-    def perform(self, obj, webasset_registry):
+    def perform(
+        self, obj: Callable[[], str], webasset_registry: WebassetRegistry
+    ) -> None:
         webasset_registry.output_path = self.absolute_path(obj())
 
 
@@ -379,14 +426,16 @@ class WebassetFilter(Action):
 
     group_class = WebassetPath
 
-    def __init__(self, name, produces=None):
+    def __init__(self, name: str, produces: str | None = None) -> None:
         self.name = name
         self.produces = produces
 
-    def identifier(self, webasset_registry):
+    def identifier(self, webasset_registry: WebassetRegistry) -> str:
         return self.name
 
-    def perform(self, obj, webasset_registry):
+    def perform(
+        self, obj: Callable[[], Filter], webasset_registry: WebassetRegistry
+    ) -> None:
         webasset_registry.register_filter(self.name, obj(), self.produces)
 
 
@@ -411,13 +460,15 @@ class WebassetMapping(Action):
 
     group_class = WebassetPath
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
 
-    def identifier(self, webasset_registry):
+    def identifier(self, webasset_registry: WebassetRegistry) -> str:
         return self.name
 
-    def perform(self, obj, webasset_registry):
+    def perform(
+        self, obj: Callable[[], str], webasset_registry: WebassetRegistry
+    ) -> None:
         webasset_registry.mapping[self.name] = obj()
 
 
@@ -436,10 +487,12 @@ class WebassetUrl(Action):
 
     group_class = WebassetPath
 
-    def identifier(self, webasset_registry):
+    def identifier(self, webasset_registry: WebassetRegistry) -> type[Self]:
         return self.__class__
 
-    def perform(self, obj, webasset_registry):
+    def perform(
+        self, obj: Callable[[], str], webasset_registry: WebassetRegistry
+    ) -> None:
         webasset_registry.url = obj()
 
 
@@ -501,14 +554,18 @@ class Webasset(Action):
     ]
     group_class = WebassetPath
 
-    def __init__(self, name, filters=None):
+    def __init__(
+        self, name: str, filters: Mapping[str, Filter | None] | None = None
+    ) -> None:
         self.name = name
         self.filters = filters
 
-    def identifier(self, webasset_registry):
+    def identifier(self, webasset_registry: WebassetRegistry) -> str:
         return self.name
 
-    def perform(self, obj, webasset_registry):
+    def perform(
+        self, obj: Callable[[], Generator[str]], webasset_registry: WebassetRegistry
+    ) -> None:
         assert inspect.isgeneratorfunction(obj), "webasset expects a generator"
         webasset_registry.register_asset(
             self.name, tuple(asset for asset in obj()), self.filters

--- a/more/webassets/tests/conftest.py
+++ b/more/webassets/tests/conftest.py
@@ -1,21 +1,27 @@
+from __future__ import annotations
+
 import os.path
 import pytest
 import tempfile
 import shutil
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 @pytest.fixture
-def tempdir():
+def tempdir() -> Generator[str]:
     directory = tempfile.mkdtemp()
     yield directory
     shutil.rmtree(directory)
 
 
 @pytest.fixture
-def current_path():
+def current_path() -> str:
     return os.path.dirname(os.path.realpath(__file__))
 
 
 @pytest.fixture
-def fixtures_path(current_path):
+def fixtures_path(current_path: str) -> str:
     return os.path.join(current_path, "fixtures")

--- a/more/webassets/tests/test_directives.py
+++ b/more/webassets/tests/test_directives.py
@@ -1,30 +1,37 @@
-import morepath
+from __future__ import annotations
+
 import os.path
+from typing import TYPE_CHECKING
+
+import morepath
 
 from more.webassets import WebassetsApp
 from more.webassets.directives import Asset
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
-def test_webasset_path(current_path):
+
+def test_webasset_path(current_path: str) -> None:
     current_path = os.path.dirname(os.path.realpath(__file__))
 
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_path():
+    def get_path() -> str:
         return "./fixtures"
 
     @App.webasset_path()
-    def get_overlapping_path():
+    def get_overlapping_path() -> str:
         return os.path.join(current_path, "./fixtures")
 
     @App.webasset_path()
-    def get_current_path():
+    def get_current_path() -> str:
         return "."
 
     @App.webasset_path()
-    def get_parent_path():
+    def get_parent_path() -> str:
         return ".."
 
     morepath.commit(App)
@@ -39,12 +46,12 @@ def test_webasset_path(current_path):
     ]
 
 
-def test_webasset_relative(current_path):
+def test_webasset_relative(current_path: str) -> None:
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_relative_path():
+    def get_relative_path() -> str:
         return "fixtures"
 
     morepath.commit(App)
@@ -54,7 +61,7 @@ def test_webasset_relative(current_path):
     ]
 
 
-def test_webasset_path_inheritance(tempdir, current_path):
+def test_webasset_path_inheritance(tempdir: str, current_path: str) -> None:
     os.mkdir(os.path.join(tempdir, "A"))
     os.mkdir(os.path.join(tempdir, "B"))
     os.mkdir(os.path.join(tempdir, "C"))
@@ -63,28 +70,28 @@ def test_webasset_path_inheritance(tempdir, current_path):
         pass
 
     @A.webasset_path()
-    def get_path_a():
+    def get_path_a() -> str:
         return os.path.join(tempdir, "A")
 
     class B(WebassetsApp):
         pass
 
     @B.webasset_path()
-    def get_path_b():
+    def get_path_b() -> str:
         return os.path.join(tempdir, "B")
 
     class C(B, A):
         pass
 
     @C.webasset_path()
-    def get_path_c():
+    def get_path_c() -> str:
         return os.path.join(tempdir, "C")
 
     class D(A, B):
         pass
 
     @D.webasset_path()
-    def get_path_c_2():
+    def get_path_c_2() -> str:
         return os.path.join(tempdir, "C")
 
     # the order of A and B is defined by the order they are scanned with
@@ -103,19 +110,19 @@ def test_webasset_path_inheritance(tempdir, current_path):
     ]
 
 
-def test_webasset_filter():
+def test_webasset_filter() -> None:
     class Base(WebassetsApp):
         pass
 
     @Base.webasset_filter("js")
-    def get_base_js_filter():
+    def get_base_js_filter() -> str:
         return "jsmin"
 
     class App(WebassetsApp):
         pass
 
     @App.webasset_filter("js")
-    def get_js_filter():
+    def get_js_filter() -> str:
         return "rjsmin"
 
     morepath.commit(App)
@@ -123,24 +130,24 @@ def test_webasset_filter():
     assert App().config.webasset_registry.filters == {"js": "rjsmin"}
 
 
-def test_webasset_filter_chain(fixtures_path):
+def test_webasset_filter_chain(fixtures_path: str) -> None:
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_path():
+    def get_path() -> str:
         return fixtures_path
 
     @App.webasset_filter("js", produces="css")
-    def foo_filter():
+    def foo_filter() -> str:
         return "jsmin"
 
     @App.webasset_filter("css")
-    def bar_filter():
+    def bar_filter() -> str:
         return "cssmin"
 
     @App.webasset("common")
-    def get_common_assets():
+    def get_common_assets() -> Generator[str]:
         yield "jquery.js"
 
     morepath.commit(App)
@@ -151,20 +158,20 @@ def test_webasset_filter_chain(fixtures_path):
     assert common[0].filters[1].name == "cssmin"
 
 
-def test_webasset_directive(tempdir, fixtures_path):
+def test_webasset_directive(tempdir: str, fixtures_path: str) -> None:
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_path():
+    def get_path() -> str:
         return fixtures_path
 
     @App.webasset_output()
-    def get_output_path():
+    def get_output_path() -> str:
         return tempdir
 
     @App.webasset("common")
-    def get_common_assets():
+    def get_common_assets() -> Generator[str]:
         yield "jquery.js"
         yield "underscore.js"
 
@@ -210,31 +217,31 @@ def test_webasset_directive(tempdir, fixtures_path):
     assert underscore[0].contents == (os.path.join(fixtures_path, "underscore.js"),)
 
 
-def test_webasset_override_filters(tempdir, fixtures_path):
+def test_webasset_override_filters(tempdir: str, fixtures_path: str) -> None:
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_path():
+    def get_path() -> str:
         return fixtures_path
 
     @App.webasset_output()
-    def get_output_path():
+    def get_output_path() -> str:
         return tempdir
 
     @App.webasset("jquery")
-    def get_jquery_asset():
+    def get_jquery_asset() -> Generator[str]:
         yield "jquery.js"
 
     @App.webasset_filter("js")
-    def get_js_filter():
+    def get_js_filter() -> str:
         return "rjsmin"
 
     class DebugApp(App):
         pass
 
     @DebugApp.webasset_filter("js")
-    def get_debug_js_filter():
+    def get_debug_js_filter() -> None:
         return None
 
     morepath.commit(DebugApp, App)
@@ -248,31 +255,33 @@ def test_webasset_override_filters(tempdir, fixtures_path):
     assert not bundles[0].filters
 
 
-def test_webasset_override_filter_through_bundle(tempdir, fixtures_path):
+def test_webasset_override_filter_through_bundle(
+    tempdir: str, fixtures_path: str
+) -> None:
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_path():
+    def get_path() -> str:
         return fixtures_path
 
     @App.webasset_output()
-    def get_output_path():
+    def get_output_path() -> str:
         return tempdir
 
     @App.webasset("jquery")
-    def get_jquery_asset():
+    def get_jquery_asset() -> Generator[str]:
         yield "jquery.js"
 
     @App.webasset_filter("js")
-    def get_js_filter():
+    def get_js_filter() -> str:
         return "rjsmin"
 
     class DebugApp(App):
         pass
 
     @DebugApp.webasset("common", filters={"js": None})
-    def get_debug_js_filter():
+    def get_debug_js_filter() -> Generator[str]:
         yield "jquery"
 
     morepath.commit(DebugApp, App)
@@ -286,24 +295,24 @@ def test_webasset_override_filter_through_bundle(tempdir, fixtures_path):
     assert not bundles[0].filters
 
 
-def test_global_filter_is_only_a_default(tempdir, fixtures_path):
+def test_global_filter_is_only_a_default(tempdir: str, fixtures_path: str) -> None:
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_path():
+    def get_path() -> str:
         return fixtures_path
 
     @App.webasset_output()
-    def get_output_path():
+    def get_output_path() -> str:
         return tempdir
 
     @App.webasset("jquery", filters={"js": None})
-    def get_jquery_asset():
+    def get_jquery_asset() -> Generator[str]:
         yield "jquery.js"
 
     @App.webasset_filter("js")
-    def get_js_filter():
+    def get_js_filter() -> str:
         return "rjsmin"
 
     morepath.commit(App)
@@ -313,28 +322,30 @@ def test_global_filter_is_only_a_default(tempdir, fixtures_path):
     assert not bundles[0].filters
 
 
-def test_global_filter_is_only_a_default_with_bundle(tempdir, fixtures_path):
+def test_global_filter_is_only_a_default_with_bundle(
+    tempdir: str, fixtures_path: str
+) -> None:
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_path():
+    def get_path() -> str:
         return fixtures_path
 
     @App.webasset_output()
-    def get_output_path():
+    def get_output_path() -> str:
         return tempdir
 
     @App.webasset("jquery", filters={"js": None})
-    def get_jquery_asset():
+    def get_jquery_asset() -> Generator[str]:
         yield "jquery.js"
 
     @App.webasset("common")
-    def get_common_asset():
+    def get_common_asset() -> Generator[str]:
         yield "jquery"
 
     @App.webasset_filter("js")
-    def get_js_filter():
+    def get_js_filter() -> str:
         return "rjsmin"
 
     morepath.commit(App)
@@ -348,20 +359,20 @@ def test_global_filter_is_only_a_default_with_bundle(tempdir, fixtures_path):
     assert not bundles[0].filters
 
 
-def test_webasset_mixed_bundles(tempdir, fixtures_path):
+def test_webasset_mixed_bundles(tempdir: str, fixtures_path: str) -> None:
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_path():
+    def get_path() -> str:
         return fixtures_path
 
     @App.webasset_output()
-    def get_output_path():
+    def get_output_path() -> str:
         return tempdir
 
     @App.webasset("common")
-    def get_jquery_asset():
+    def get_jquery_asset() -> Generator[str]:
         yield "jquery.js"
         yield "extra.css"
 
@@ -377,24 +388,24 @@ def test_webasset_mixed_bundles(tempdir, fixtures_path):
     assert bundles[1].contents == (os.path.join(fixtures_path, "extra.css"),)
 
 
-def test_webasset_compiled_bundle(tempdir, fixtures_path):
+def test_webasset_compiled_bundle(tempdir: str, fixtures_path: str) -> None:
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_path():
+    def get_path() -> str:
         return fixtures_path
 
     @App.webasset_output()
-    def get_output_path():
+    def get_output_path() -> str:
         return tempdir
 
     @App.webasset_filter("scss")
-    def get_scss_filter():
+    def get_scss_filter() -> str:
         return "libsass"
 
     @App.webasset("theme")
-    def get_jquery_asset():
+    def get_jquery_asset() -> Generator[str]:
         yield "main.scss"
         yield "extra.css"
 
@@ -410,34 +421,34 @@ def test_webasset_compiled_bundle(tempdir, fixtures_path):
     assert bundles[1].contents == (os.path.join(fixtures_path, "extra.css"),)
 
 
-def test_webasset_environment(tempdir, fixtures_path):
+def test_webasset_environment(tempdir: str, fixtures_path: str) -> None:
     class App(WebassetsApp):
         pass
 
     @App.webasset_path()
-    def get_path():
+    def get_path() -> str:
         return fixtures_path
 
     @App.webasset_output()
-    def get_output_path():
+    def get_output_path() -> str:
         return tempdir
 
     @App.webasset_filter("scss")
-    def get_scss_filter():
+    def get_scss_filter() -> str:
         return "libsass"
 
     @App.webasset("js")
-    def get_js_asset():
+    def get_js_asset() -> Generator[str]:
         yield "jquery.js"
         yield "underscore.js"
 
     @App.webasset("css")
-    def get_css_asset():
+    def get_css_asset() -> Generator[str]:
         yield "main.scss"
         yield "extra.css"
 
     @App.webasset("common")
-    def get_common_assets():
+    def get_common_assets() -> Generator[str]:
         yield "js"
         yield "css"
 

--- a/more/webassets/tests/test_webassets.py
+++ b/more/webassets/tests/test_webassets.py
@@ -1,15 +1,26 @@
+from __future__ import annotations
+
 import more.webassets
 import morepath
 import os
 import pytest
 
-from datetime import datetime
+from datetime import datetime, timezone
 from more.webassets import WebassetsApp
 from more.webassets.tweens import is_subpath, has_insecure_path_element
+from typing import TYPE_CHECKING
 from webtest import TestApp as Client
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from more.webassets.core import IncludeRequest
 
-def prepare_fixtures(directory):
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def prepare_fixtures(directory: str) -> None:
     os.mkdir(os.path.join(directory, "common"))
     os.mkdir(os.path.join(directory, "output"))
     os.mkdir(os.path.join(directory, "theme"))
@@ -50,7 +61,7 @@ def prepare_fixtures(directory):
         """)
 
 
-def spawn_test_app(tempdir):
+def spawn_test_app(tempdir: str) -> WebassetsApp:
     prepare_fixtures(tempdir)
 
     html = """
@@ -62,7 +73,7 @@ def spawn_test_app(tempdir):
         </html>
     """
 
-    def render_plain(content, request):
+    def render_plain(content: str, request: morepath.Request) -> morepath.Response:
         response = morepath.Response(content)
         response.content_type = "text/plain"
         return response
@@ -71,36 +82,36 @@ def spawn_test_app(tempdir):
         pass
 
     @App.webasset_path()
-    def get_default_assets_path():
+    def get_default_assets_path() -> str:
         return os.path.join(tempdir, "common")
 
     @App.webasset_path()
-    def get_theme_assets_path():
+    def get_theme_assets_path() -> str:
         return os.path.join(tempdir, "theme")
 
     @App.webasset_output()
-    def get_output_path():
+    def get_output_path() -> str:
         return os.path.join(tempdir, "output")
 
     @App.webasset_filter("js")
-    def get_js_filter():
+    def get_js_filter() -> str:
         return "rjsmin"
 
     @App.webasset_filter("scss")
-    def get_scss_filter():
+    def get_scss_filter() -> str:
         return "libsass"
 
     @App.webasset(name="common")
-    def get_common_assets():
+    def get_common_assets() -> Generator[str]:
         yield "jquery.js"
         yield "underscore.js"
 
     @App.webasset(name="extra")
-    def get_extra_asset():
+    def get_extra_asset() -> Generator[str]:
         yield "extra.js"
 
     @App.webasset(name="theme")
-    def get_theme_asset():
+    def get_theme_asset() -> Generator[str]:
         yield "main.scss"
 
     @App.path("")
@@ -108,26 +119,26 @@ def spawn_test_app(tempdir):
         pass
 
     @App.html(model=Root)
-    def index(self, request):
+    def index(self: Root, request: IncludeRequest) -> str:
         bundle = request.params.get("bundle")
 
-        if bundle:
+        if bundle and isinstance(bundle, str):
             request.include(bundle)
 
         return html
 
     @App.view(model=Root, name="plain", render=render_plain)
-    def plain(self, request):
+    def plain(self: Root, request: IncludeRequest) -> str:
         request.include("common")
         return html
 
     @App.html(model=Root, name="put", request_method="PUT")
-    def put(self, request):
+    def put(self: Root, request: IncludeRequest) -> str:
         request.include("common")
         return html
 
     @App.html(model=Root, name="alljs")
-    def alljs(self, request):
+    def alljs(self: Root, request: IncludeRequest) -> str:
         request.include("common")
         request.include("extra")
         return html
@@ -138,7 +149,7 @@ def spawn_test_app(tempdir):
     return App()
 
 
-def test_inject_webassets(tempdir):
+def test_inject_webassets(tempdir: str) -> None:
     client = Client(spawn_test_app(tempdir))
 
     assert "<head></head>" in client.get("/").text
@@ -166,7 +177,7 @@ def test_inject_webassets(tempdir):
     assert page.find("common.bundle.js") < page.find("extra.bundle.js")
 
 
-def test_publish_webassets(tempdir):
+def test_publish_webassets(tempdir: str) -> None:
     client = Client(spawn_test_app(tempdir))
 
     url = "/assets/common.bundle.js?ddc71aa3"
@@ -177,9 +188,11 @@ def test_publish_webassets(tempdir):
 
     client.get("?bundle=common")
 
-    assert client.get(url).text == "var $=function(){};var _=function(){};"
-    assert client.get(url).expires.year == datetime.utcnow().year + 10
-    assert client.get(url).content_type == "text/javascript"
+    response = client.get(url)
+    assert response.text == "var $=function(){};var _=function(){};"
+    assert response.expires is not None
+    assert response.expires.year == utcnow().year + 10
+    assert response.content_type == "text/javascript"
 
     # do the same for css
     url = "/assets/theme.bundle.css?32fda411"
@@ -188,24 +201,26 @@ def test_publish_webassets(tempdir):
 
     client.get("?bundle=theme")
 
-    assert client.get(url).text == "body a {\n  color: blue; }\n"
-    assert client.get(url).expires.year == datetime.utcnow().year + 10
-    assert client.get(url).content_type == "text/css"
+    response = client.get(url)
+    assert response.text == "body a {\n  color: blue; }\n"
+    assert response.expires is not None
+    assert response.expires.year == utcnow().year + 10
+    assert response.content_type == "text/css"
 
 
-def test_webassets_unhandled_content_type(tempdir):
+def test_webassets_unhandled_content_type(tempdir: str) -> None:
     client = Client(spawn_test_app(tempdir))
 
     assert "<head></head>" in client.get("/plain").text
 
 
-def test_webassets_unhandled_request_method(tempdir):
+def test_webassets_unhandled_request_method(tempdir: str) -> None:
     client = Client(spawn_test_app(tempdir))
 
     assert "<head></head>" in client.put("/put").text
 
 
-def test_is_subpath(tempdir):
+def test_is_subpath(tempdir: str) -> None:
     assert is_subpath("/", "/test")
     assert is_subpath("/asdf", "/asdf/asdf")
     assert not is_subpath("/asdf/", "/asdf")
@@ -213,7 +228,7 @@ def test_is_subpath(tempdir):
     assert not is_subpath("/a", "/a/../b")
 
 
-def test_insecure_path_element():
+def test_insecure_path_element() -> None:
     assert has_insecure_path_element("../test.txt")
     assert has_insecure_path_element("./test.txt")
     assert has_insecure_path_element("/test.txt")

--- a/more/webassets/tweens.py
+++ b/more/webassets/tweens.py
@@ -1,14 +1,24 @@
+from __future__ import annotations
+
 import os
 import time
-import webob
-
 from datetime import timedelta
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
+
+import webob.exc
 from webob.static import FileApp
 
-try:
-    from urllib import unquote
-except ImportError:
-    from urllib.parse import unquote
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from webassets.env import Environment
+    from webob import Response as BaseResponse
+
+    from morepath.request import Request
+    from morepath.types import StrPath, Tween
+
+    from .core import IncludeRequest
 
 
 # content types and methods that get handled by the injector/publisher
@@ -16,7 +26,7 @@ CONTENT_TYPES = {"text/html", "application/xhtml+xml"}
 METHODS = {"GET", "POST", "HEAD"}
 
 # arbitrarily define forever as 10 years in the future
-FOREVER = timedelta(days=365 * 10).total_seconds()
+FOREVER = int(timedelta(days=365 * 10).total_seconds())
 
 
 # what separators does this operating system provide that are not a slash?
@@ -26,7 +36,7 @@ _os_alt_seps = {sep for sep in [os.path.sep, os.path.altsep] if sep not in (None
 _insecure_elements = {"..", ".", ""} | _os_alt_seps
 
 
-def is_subpath(directory, path):
+def is_subpath(directory: StrPath, path: StrPath) -> bool:
     """Returns true if the given path is inside the given directory."""
     directory = os.path.join(os.path.realpath(directory), "")
     path = os.path.realpath(path)
@@ -36,7 +46,7 @@ def is_subpath(directory, path):
     return os.path.commonprefix([path, directory]) == directory
 
 
-def has_insecure_path_element(path):
+def has_insecure_path_element(path: str) -> bool:
     """Returns true if the given path contains an insecure path element.
     That is '..' or '.' or ''
     """
@@ -49,12 +59,12 @@ def has_insecure_path_element(path):
 class InjectorTween:
     """Injects the webasset urls into the response."""
 
-    def __init__(self, environment, handler):
+    def __init__(self, environment: Environment, handler: Tween) -> None:
         self.environment = environment
         self.handler = handler
-        self._urls = {}
+        self._urls: dict[str, list[str]] = {}
 
-    def urls_by_resource(self, resource):
+    def urls_by_resource(self, resource: str) -> list[str]:
         if self.environment.debug or resource not in self._urls:
             self._urls[resource] = []
 
@@ -69,7 +79,9 @@ class InjectorTween:
 
         return self._urls[resource]
 
-    def urls_to_inject(self, request, suffix=None):
+    def urls_to_inject(
+        self, request: IncludeRequest, suffix: str | None = None
+    ) -> Generator[str]:
         for resource in request.included_assets:
             for url in self.urls_by_resource(resource):
                 filename = url.split("?")[0]
@@ -79,7 +91,7 @@ class InjectorTween:
 
                 yield "/" + url
 
-    def __call__(self, request):
+    def __call__(self, request: IncludeRequest) -> BaseResponse:
         response = self.handler(request)
 
         if request.method not in METHODS:
@@ -120,16 +132,17 @@ class PublisherTween:
 
     """
 
-    def __init__(self, environment, handler):
+    def __init__(self, environment: Environment, handler: Tween) -> None:
         self.environment = environment
         self.handler = handler
 
-    def __call__(self, request):
+    def __call__(self, request: Request) -> BaseResponse:
         publisher_signature = request.path_info_peek()
 
         if publisher_signature != self.environment.url:
             return self.handler(request)
 
+        assert publisher_signature is not None
         subpath = request.path_info.replace(publisher_signature, "").strip("/")
         subpath = unquote(subpath)
 

--- a/more/webassets/types.py
+++ b/more/webassets/types.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from collections.abc import Collection
+from typing import TypeAlias
+
+Filter: TypeAlias = Collection[str] | str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">= 3.10"
+# TODO: Pin morepath to >=1
 dependencies = ["morepath", "ordered-set", "webassets", "webob"]
 
 [project.urls]
@@ -33,9 +34,14 @@ Changelog = "https://github.com/morepath/more.webassets/blob/master/HISTORY.rst"
 test = ["libsass", "pytest >= 8", "pytest-env", "WebTest"]
 coverage = ["pytest-cov"]
 lint = ["black", "flake8", "flake8-pyproject"]
+mypy = ["mypy", "pytest", "types-WebOb", "types-WebTest"]
+pyright = ["pyright", "pytest", "types-WebOb", "types-WebTest", "WebTest >= 2.0.14"]
 
 [tool.setuptools.packages]
 find = {}
+
+[tool.setuptools.package-data]
+"more.webassets" = ["py.typed"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst", "HISTORY.rst"]}
@@ -47,7 +53,7 @@ addopts = ["-vv"]
 env = ["RUN_ENV=test"]
 
 [tool.coverage.run]
-omit = ["more/webassets/tests/*"]
+omit = ["more/webassets/tests/*", "more/webassets/types.py"]
 source = ["more/webassets"]
 
 [tool.coverage.report]
@@ -57,6 +63,12 @@ show_missing = true
 show-source = true
 ignore = ["E203", "E731", "W503", "N801"]
 max-line-length = 88
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_unreachable = true
+untyped_calls_exclude = "webassets"
 
 [tool.bumpversion]
 current_version = "0.5.1"
@@ -97,12 +109,14 @@ env_list = [
     "pypy3",
     "coverage",
     "pre-commit",
+    "mypy",
+    "pyright",
 ]
 skip_missing_interpreters = true
 
 [tool.tox.gh.python]
 "3.10" = ["py310"]
-"3.11" = ["py311"]
+"3.11" = ["py311", "mypy", "pyright"]
 "3.12" = ["py312"]
 "3.13" = ["py313"]
 "3.14" = ["py314", "pre-commit", "coverage"]
@@ -111,13 +125,14 @@ skip_missing_interpreters = true
 [tool.tox.env_run_base]
 package = "editable"
 extras = ["test"]
+deps = ["-r{tox_root}/requirements/corelibs.txt"]
 commands = [["pytest", "{posargs:more}"]]
 
 [tool.tox.env.coverage]
 base_python = ["python3"]
 extras = ["test", "coverage"]
 commands = [
-    ["pytest", "--cov", "--cov-fail-under=95", "{posargs:more}"],
+    ["pytest", "--cov", "--cov-fail-under=94", "{posargs:more}"],
 ]
 
 [tool.tox.env.pre-commit]
@@ -126,4 +141,26 @@ package = "skip"
 deps = ["pre-commit"]
 commands = [
     ["pre-commit", "run", "--all-files"],
+]
+
+[tool.tox.env.mypy]
+base_python = ["python3"]
+extras = ["mypy"]
+commands = [
+    ["mypy", "-p", "more.webassets", "--python-version", "3.10"],
+    ["mypy", "-p", "more.webassets", "--python-version", "3.11"],
+    ["mypy", "-p", "more.webassets", "--python-version", "3.12"],
+    ["mypy", "-p", "more.webassets", "--python-version", "3.13"],
+    ["mypy", "-p", "more.webassets", "--python-version", "3.14"],
+]
+
+[tool.tox.env.pyright]
+base_python = ["python3"]
+extras = ["pyright"]
+commands = [
+    ["pyright", "more/webassets", "--pythonversion", "3.10"],
+    ["pyright", "more/webassets", "--pythonversion", "3.11"],
+    ["pyright", "more/webassets", "--pythonversion", "3.12"],
+    ["pyright", "more/webassets", "--pythonversion", "3.13"],
+    ["pyright", "more/webassets", "--pythonversion", "3.14"],
 ]

--- a/requirements/corelibs.txt
+++ b/requirements/corelibs.txt
@@ -1,0 +1,5 @@
+# Points to the master branches of Morepath, Reg and Dectate on Github
+git+https://github.com/morepath/reg.git@master#egg=reg
+git+https://github.com/morepath/dectate.git@master#egg=dectate
+git+https://github.com/morepath/importscan.git@master#egg=importscan
+git+https://github.com/morepath/morepath.git@master#egg=morepath

--- a/requirements/develop.txt
+++ b/requirements/develop.txt
@@ -1,3 +1,6 @@
+# sources
+-r corelibs.txt
+
 # development
 -e '.[test,coverage,lint]'
 pre-commit


### PR DESCRIPTION
This also slightly improves the robustness of specifying filters as `None`, it already worked in most cases, since it is the intended way to remove a filter in a derived application (you override the existing filter with `None`), but it did not work for filters applied through product chains.

This also fixes the broken `Asset.__eq__`, which previously always returned `True`.

This also deals with the `datetime.utcnow` related deprecation warnings in a couple of the tests.

This will depend on morepath >= 1, because of `IncludeRequest`, but since we haven't bumped the version number yet, we also can't add the pin yet.

\cc @henri-hulski 